### PR TITLE
Add message for missing filename error

### DIFF
--- a/editor/editor.go
+++ b/editor/editor.go
@@ -135,6 +135,12 @@ func (e *Editor) Start() {
 			}
 		}
 	}()
+	
+	// Exit gracefully when no filename is provided.
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "No filename provided. Example: `kod example.txt`\n")
+		os.Exit(1)
+	}
 
 	path := os.Args[1]
 	vp := NewViewport(e.screen, 0, 0)


### PR DESCRIPTION
The editor currently expects a filename to be given whenever it is started. When this is not done, the message is not clear.
The new message clearly states that this must be done.

#5 