### PR TITLE
Fixing linecache

### DIFF
--- a/editor/linecache.go
+++ b/editor/linecache.go
@@ -61,11 +61,10 @@ func (lc *LineCache) ApplyUpdate(update *rpc.Update) {
 			if op.N < len(lc.lines) {
 				firstNLines := append(lc.lines[:0], lc.lines[:op.N]...)
 				lc.lines = lc.lines[op.N:]
-				newLines = append(newLines, firstNLines...) //remove from lc.lines
+				newLines = append(newLines, firstNLines...)
 				continue
 			} else {
-				//allNLines := append(lc.lines[:0], lc.lines[0:]...)
-				newLines = append(newLines, lc.lines...) //remove from lc.lines
+				newLines = append(newLines, lc.lines...)
 				lc.lines = make([]*Line, 0, 10)
 				op.N -= len(lc.lines)
 			}

--- a/kod.go
+++ b/kod.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/linde12/kod/editor"
+	"./editor"
 )
 
 type readwriter struct {


### PR DESCRIPTION
@linde12 
Here's my attempt to fixing this. It might not be optimal as Im a Go beginner. I have referred to xrl crate which is used by xterm. 
There are still couple of issues I see. 2 important ones are:
1) 'update' case in linecache.go has not changed. Not sure how I can test this piece of code. No matter what I do in editor, 'update' op is never returned by core. Leaving this as is. 
2) If you move cursor to end of last line and hit return, the cursor doesnt move to next line. But if you start typing it enters the line in correct location. 

Other issues (like line numbers in my viewport doesnt update as I expand my current window) I think are unrelated to linecache. But I may be wrong. 