### PR TITLE
kod: update editor import path to absolute.

### DIFF
--- a/kod.go
+++ b/kod.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"os/exec"
 
-	"./editor"
+	"github.com/linde12/kod/editor"
 )
 
 type readwriter struct {


### PR DESCRIPTION
Absolute import paths are 1. more conventional and 2. work better with
the Go toolchain.