### PR TITLE
Fix cursor placement is wrong on the last line (#13)

### DIFF
--- a/editor/view.go
+++ b/editor/view.go
@@ -120,13 +120,12 @@ func (v *View) Draw() {
 				v.view.SetContent(visualX, y, char, nil, style)
 				visualX++
 			}
-
-			if len(line.Cursors) != 0 {
-				// TODO: Verify if xi-core will take care of tabs for us
-				cX := GetCursorVisualX(line.Cursors[0], line.Text)
-				// TODO: Multiple cursor support
-				v.view.ShowCursor(cX, y)
-			}
+		}
+		if len(line.Cursors) != 0 {
+			// TODO: Verify if xi-core will take care of tabs for us
+			cX := GetCursorVisualX(line.Cursors[0], line.Text)
+			// TODO: Multiple cursor support
+			v.view.ShowCursor(cX, y)
 		}
 	}
 }


### PR DESCRIPTION
Moved the code where the cursor is updated outside of the loop that checks the text of the lines and since the last line doesn't have text the cursor update was not executed.
#13 