### PR TITLE
Fix terminal glitches

### DIFF
--- a/editor/editor.go
+++ b/editor/editor.go
@@ -129,6 +129,12 @@ func (e *Editor) handleRequests() {
 }
 
 func (e *Editor) Start() {
+	// Exit gracefully when no filename is provided.
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "No filename provided. Example: `kod example.txt`\n")
+		os.Exit(1)
+	}
+
 	e.initScreen()
 	defer e.screen.Fini()
 
@@ -142,12 +148,6 @@ func (e *Editor) Start() {
 			}
 		}
 	}()
-
-	// Exit gracefully when no filename is provided.
-	if len(os.Args) < 2 {
-		fmt.Fprintf(os.Stderr, "No filename provided. Example: `kod example.txt`\n")
-		os.Exit(1)
-	}
 
 	path := os.Args[1]
 	vp := NewViewport(e.screen, 0, 0)

--- a/editor/editor.go
+++ b/editor/editor.go
@@ -185,7 +185,7 @@ func (e *Editor) Start() {
 			switch ev := event.(type) {
 			case *tcell.EventKey:
 				switch ev.Key() {
-				case tcell.KeyF1:
+				case tcell.KeyCtrlQ:
 					close(quit)
 				}
 			case *tcell.EventResize:

--- a/editor/view.go
+++ b/editor/view.go
@@ -1,7 +1,6 @@
 package editor
 
 import (
-	"os"
 	"strconv"
 
 	"github.com/gdamore/tcell"
@@ -164,9 +163,6 @@ func (v *View) HandleEvent(ev tcell.Event) {
 					v.MoveWordLeft()
 				case tcell.KeyRight:
 					v.MoveWordRight()
-				case tcell.KeyCtrlQ:
-					// TODO: Send CloseView to xi and cleanup tcell
-					os.Exit(0)
 				case tcell.KeyCtrlS:
 					v.Save()
 				case tcell.KeyCtrlU:


### PR DESCRIPTION
First commit (e40beee) removes F1 and assigns its functionality to Ctrl+Q which was used to exit Kod before but it wasn't working properly while F1 was. Issue #24.

Second commit (a1c7c80) checks if filename is provided before starting tcell ui, so it doesn't glitch the terminal.

