### PR TITLE
Fix gutter line numbers are wrongly displayed (#15)

### DIFF
--- a/editor/linecache.go
+++ b/editor/linecache.go
@@ -51,8 +51,8 @@ func (lc *LineCache) ApplyUpdate(update *rpc.Update) {
 				continue
 			} else {
 				newLines = append(newLines, lc.lines...)
-				lc.lines = make([]*Line, 0, 10)
 				op.N -= len(lc.lines)
+				lc.lines = make([]*Line, 0, 10)
 			}
 
 			if lc.invalidAfter >= op.N {
@@ -97,4 +97,3 @@ func (lc *LineCache) ApplyUpdate(update *rpc.Update) {
 	lc.invalidBefore = newInvalidBefore
 	lc.invalidAfter = newInvalidAfter
 }
-


### PR DESCRIPTION
Temporary fix. This makes newInvalidAfter the remain number of lines.

I'm not entirely sure how linecache works, so it should be a temporary because I don't know what side effects it could have but seems fine so far.

Fixes #15