### PR TITLE
Fix vertical scroll and update implementation of linecache

### DIFF
--- a/editor/editor.go
+++ b/editor/editor.go
@@ -121,8 +121,7 @@ func (e *Editor) handleRequests() {
 		case *rpc.ScrollTo:
 			e.updates <- func() {
 				scrollTo := msg.Value.(*rpc.ScrollTo)
-				e.Views[scrollTo.ViewID].view.MakeVisibleY(scrollTo.Line)
-				e.Views[scrollTo.ViewID].gutter.MakeVisibleY(scrollTo.Line)
+				e.Views[scrollTo.ViewID].MakeLineVisible(scrollTo.Line)
 				e.Views[scrollTo.ViewID].view.ShowCursor(scrollTo.Col, scrollTo.Line)
 			}
 		}

--- a/editor/editor.go
+++ b/editor/editor.go
@@ -118,6 +118,13 @@ func (e *Editor) handleRequests() {
 
 				log.Printf("Theme:%v", theme)
 			}
+		case *rpc.ScrollTo:
+			e.updates <- func() {
+				scrollTo := msg.Value.(*rpc.ScrollTo)
+				e.Views[scrollTo.ViewID].view.MakeVisibleY(scrollTo.Line)
+				e.Views[scrollTo.ViewID].gutter.MakeVisibleY(scrollTo.Line)
+				e.Views[scrollTo.ViewID].view.ShowCursor(scrollTo.Col, scrollTo.Line)
+			}
 		}
 
 		// TODO: Better way to signal redraw?

--- a/editor/inputhandler.go
+++ b/editor/inputhandler.go
@@ -87,3 +87,7 @@ func (ih *InputHandler) Save() {
 		},
 	})
 }
+
+func (ih *InputHandler) Scroll(lineStart, lineEnd int) {
+	ih.edit(rpc.Object{"method": "scroll", "params": rpc.Array{lineStart, lineEnd}})
+}

--- a/editor/linecache.go
+++ b/editor/linecache.go
@@ -79,6 +79,9 @@ func (lc *LineCache) ApplyUpdate(update *rpc.Update) {
 		case "invalidate":
 			lc.addInvalid(newLines, &newInvalidBefore, &newInvalidAfter, op.N)
 		case "ins":
+			for i := 0; i < newInvalidAfter; i++ {
+				newLines = append(newLines, nil)
+			}
 			for _, line := range op.Lines {
 				newline := NewLine(line.Text, line.Cursor, line.Styles)
 				newLines = append(newLines, newline)

--- a/editor/view.go
+++ b/editor/view.go
@@ -100,6 +100,7 @@ func (v *View) Draw() {
 
 	// TODO: Line numbers in a separate viewport
 	for y, line := range v.lines {
+		nLine := y + v.invalidBefore
 		visualX := 0
 		for x, char := range []rune(line.Text) {
 			// TODO: Do this somewhere else
@@ -113,12 +114,12 @@ func (v *View) Draw() {
 			if char == '\t' {
 				ts := tabSize - (visualX % tabSize)
 				for i := 0; i < ts; i++ {
-					v.view.SetContent(visualX+i, y, ' ', nil, style)
+					v.view.SetContent(visualX+i, nLine, ' ', nil, style)
 				}
 				visualX += ts
 			} else if char != '\n' {
 				// TODO: Trim newline in a better way?
-				v.view.SetContent(visualX, y, char, nil, style)
+				v.view.SetContent(visualX, nLine, char, nil, style)
 				visualX++
 			}
 		}
@@ -126,7 +127,7 @@ func (v *View) Draw() {
 			// TODO: Verify if xi-core will take care of tabs for us
 			cX := GetCursorVisualX(line.Cursors[0], line.Text)
 			// TODO: Multiple cursor support
-			v.view.ShowCursor(cX, y)
+			v.view.ShowCursor(cX, nLine)
 		}
 	}
 	lineStart, lineEnd := v.view.GetViewport()

--- a/editor/view.go
+++ b/editor/view.go
@@ -83,18 +83,16 @@ func (v *View) Draw() {
 	// render line numbers
 	// TODO: improve, alot... :-)
 	style := defaultStyle.Foreground(tcell.ColorBlue)
-	lc := v.LineCache
-	tot := lc.invalidBefore + len(v.lines) + lc.invalidAfter
 	width := len(strconv.Itoa(len(v.lines) + v.LineCache.invalidBefore))
 
 	v.gutter.SetWidth(width + 1)
 	v.view.SetOffsetX(width + 2)
-
-	for i := 0; i < tot; i++ {
-		txt := ralign(strconv.Itoa(lc.invalidBefore+i), width)
+	for i := 0; i < len(v.lines); i++ {
+		nLine := i + v.invalidBefore
+		txt := ralign(strconv.Itoa(nLine), width)
 		width := len(txt)
 		for x := 0; x < width; x++ {
-			v.gutter.SetContent(1+x, i, rune(txt[x]), nil, style)
+			v.gutter.SetContent(1+x, nLine, rune(txt[x]), nil, style)
 		}
 	}
 

--- a/editor/view.go
+++ b/editor/view.go
@@ -20,11 +20,13 @@ type View struct {
 	*LineCache
 	*InputHandler
 
-	ID     string
-	view   *Viewport
-	gutter *Viewport
-	xi     *rpc.Connection
-	ViewID string
+	ID        string
+	view      *Viewport
+	gutter    *Viewport
+	xi        *rpc.Connection
+	ViewID    string
+	lineStart int
+	lineEnd   int
 }
 
 var tmpStyle tcell.Style
@@ -126,6 +128,12 @@ func (v *View) Draw() {
 			// TODO: Multiple cursor support
 			v.view.ShowCursor(cX, y)
 		}
+	}
+	lineStart, lineEnd := v.view.GetViewport()
+	if lineStart != v.lineStart || lineEnd != v.lineEnd {
+		v.Scroll(lineStart, lineEnd)
+		v.lineStart = lineStart
+		v.lineEnd = lineEnd
 	}
 }
 

--- a/editor/view.go
+++ b/editor/view.go
@@ -129,6 +129,11 @@ func (v *View) Draw() {
 	}
 }
 
+func (v *View) MakeLineVisible(line int) {
+	v.view.MakeVisibleY(line)
+	v.gutter.MakeVisibleY(line)
+}
+
 func (v *View) HandleEvent(ev tcell.Event) {
 	switch e := ev.(type) {
 	case *tcell.EventKey:

--- a/editor/view.go
+++ b/editor/view.go
@@ -98,6 +98,9 @@ func (v *View) Draw() {
 
 	// TODO: Line numbers in a separate viewport
 	for y, line := range v.lines {
+		if line == nil {
+			continue
+		}
 		nLine := y + v.invalidBefore
 		visualX := 0
 		for x, char := range []rune(line.Text) {

--- a/rpc/connection.go
+++ b/rpc/connection.go
@@ -99,6 +99,10 @@ func (c *Connection) recv() {
 				var themeChanged ThemeChanged
 				json.Unmarshal(msg.Params, &themeChanged)
 				c.Messages <- &Message{msg.Method, &themeChanged}
+			case "scroll_to":
+				var scrollTo ScrollTo
+				json.Unmarshal(msg.Params, &scrollTo)
+				c.Messages <- &Message{msg.Method, &scrollTo}
 			default:
 				log.Println("unhandled request: " + msg.Method)
 			}

--- a/rpc/scrollto.go
+++ b/rpc/scrollto.go
@@ -1,0 +1,7 @@
+package rpc
+
+type ScrollTo struct {
+	ViewID string `json:"view_id"`
+	Col    int    `json:"col"`
+	Line   int    `json:"line"`
+}


### PR DESCRIPTION
I added support for vertical scrolling creating an "offset" on viewport to know how many lines should Kod scroll based on number of lines and invalid lines before the document.
I also added some helper methods for viewport that I got from tcell. Those provide an easy way to scroll the viewport and make a part of the viewport visible.
Now Kod is not responsible to move the cursor and Xi core is. Cursor will only move when there's a notification from Xi core.
When Kod scrolls, it now sends a notification to Xi core to let it know the new viewport.
Finally, I updated the implementation of linecache because there were some problems when Xi invalidates lines and viewport was scrolled.